### PR TITLE
Add concise privacy policy

### DIFF
--- a/app/content/articles/index.ts
+++ b/app/content/articles/index.ts
@@ -7,6 +7,7 @@ import * as InteractiveEducation from "./interactive-education.mdx";
 import * as Resume from "./resume.mdx";
 import * as AboutMe from "./about-me.mdx";
 import * as AiNovelViewSynthesis from "./ai-novel-view-synthesis.mdx";
+import * as Privacy from "./privacy.mdx";
 
 export const projects = [
   ThisPortfolio,
@@ -22,4 +23,5 @@ export const articles = [
   ...projects,
   Resume,
   AboutMe,
+  Privacy,
 ];

--- a/app/content/articles/privacy.mdx
+++ b/app/content/articles/privacy.mdx
@@ -1,0 +1,18 @@
+export const id = "privacy"
+export const title = "Privacy Policy"
+export const description = "GDPR notice"
+export const img = null
+
+# Privacy Policy
+
+This website does not use cookies, analytics, or contact forms.
+
+When you visit, your IP address and basic request data (like time and browser type) are logged by our hosting provider, Vercel Inc., for security and technical reasons. This data is stored temporarily and automatically deleted after a short period.
+
+The legal basis for this processing is our legitimate interest under Art. 6(1)(f) GDPR to operate a secure and functional website.
+
+We do not share your data with third parties. Vercel acts as our processor and complies with GDPR requirements.
+
+If you have questions about your data or want to request deletion, contact:
+Alexander Horner – <a href="mailto:opener.foray_4v@icloud.com">opener.foray_4v@icloud.com</a>
+You also have the right to lodge a complaint with a data protection authority.

--- a/app/routes/_home-layout.tsx
+++ b/app/routes/_home-layout.tsx
@@ -255,9 +255,8 @@ const CallToAction = () => {
 const Footer = () => {
   return (
     <footer className="bg-gray-50 text-gray-600 py-10 text-center">
-      <div className="text-sm space-x-2">
-         © 2024 Alexander Horner
-         <Link to="/privacy" className="underline">Privacy</Link>
+      <div className="text-sm">
+         © 2024 Alexander Horner <Link to="/privacy" className="underline">Privacy</Link>
       </div>
     </footer>
   )

--- a/app/routes/_home-layout.tsx
+++ b/app/routes/_home-layout.tsx
@@ -255,8 +255,9 @@ const CallToAction = () => {
 const Footer = () => {
   return (
     <footer className="bg-gray-50 text-gray-600 py-10 text-center">
-      <div className="text-sm">
+      <div className="text-sm space-x-2">
          © 2024 Alexander Horner
+         <Link to="/privacy" className="underline">Privacy</Link>
       </div>
     </footer>
   )

--- a/app/routes/_home-layout.tsx
+++ b/app/routes/_home-layout.tsx
@@ -256,7 +256,7 @@ const Footer = () => {
   return (
     <footer className="bg-gray-50 text-gray-600 py-10 text-center">
       <div className="text-sm">
-         © 2024 Alexander Horner <Link to="/privacy" className="underline">Privacy</Link>
+         © 2024 Alexander Horner <Link preventScrollReset to="/privacy" className="underline">Privacy</Link>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary
- remove the unused Impressum page
- link only to the Privacy Policy in the footer
- expand the Privacy Policy contents

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_6876d047c7f88321baa116f7e4da7e9b